### PR TITLE
Fix config bug where apiUrl and keys were switched

### DIFF
--- a/lib/storage/config.js
+++ b/lib/storage/config.js
@@ -37,9 +37,9 @@ class Config {
       apiSecret,
       publicKey,
       privateKey,
-      apiUrl,
       publicSigningKey,
-      privateSigningKey
+      privateSigningKey,
+      apiUrl
     )
   }
 


### PR DESCRIPTION
Master version of the SDK has a bug where config obj is improperly initialized.