### PR TITLE
Modify token expiry detection for account to rely on expires_in response

### DIFF
--- a/lib/identity/client.js
+++ b/lib/identity/client.js
@@ -21,7 +21,13 @@ async function fetchToken(client, appName) {
       body: urlEncodeData(bodyData),
     }
   )
-  return credentialedDecodeResponse(request)
+  const response = await credentialedDecodeResponse(request)
+  // record the time this token will expire based on the info response.
+  // Since we set this date based on the expires_in response, adding 5 seconds
+  // helps ensure we do not attempt to use a token that is expired but shows as
+  // valid due to network latency.
+  response.expires = Math.floor(Date.now() / 1000) + response.expires_in - 5
+  return response
 }
 
 class Client extends PartialClient {
@@ -53,8 +59,8 @@ class Client extends PartialClient {
   }
 
   async tokenInfo() {
-    const fiveFromNow = Math.floor(Date.now() / 1000) + 5 * 60
-    if (!this._tokenInfo || this._tokenInfo.expires < fiveFromNow) {
+    const now = Math.floor(Date.now() / 1000)
+    if (!this._tokenInfo || this._tokenInfo.expires < now) {
       const tokenInfo = await fetchToken(this, this.config.appName)
       this._tokenInfo = tokenInfo
     }


### PR DESCRIPTION
account tokens were not properly refreshing. This modifies the refresh logic to actually detect and refresh the account token as needed in Keycloak 11 land.