### PR TITLE
Adjustments for stable tests

### DIFF
--- a/__tests__/environment/browser.js
+++ b/__tests__/environment/browser.js
@@ -29,8 +29,8 @@ const TestIdleTimeoutMilliseconds = parseInt(
   10
 )
 const TestEnvironment = process.env.TEST_ENVIRONMENT
-const TestLocalUseProd = process.env.TEST_LOCAL_USE_PROD
-const TestLocalUseCDN = process.env.TEST_LOCAL_USE_CDN
+const TestLocalUseProd = process.env.TEST_LOCAL_USE_PROD === 'true'
+const TestLocalUseCDN = process.env.TEST_LOCAL_USE_CDN === 'true'
 /* Continuous Integration / Build Server Execution UID */
 const TestJobNumber = process.env.TRAVIS_JOB_NUMBER
   ? `#${process.env.TRAVIS_JOB_NUMBER}`

--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -26,17 +26,10 @@ beforeAll(async () => {
     testRecords.push(written)
   }
   // wait for records to be indexed
-  for (let i = 0; i < 10; i++) {
-    const request = new Tozny.types.Search()
-    request.match({ records: testRecords[0].meta.recordId })
-    const resultQuery = await writer.search(request)
-    const found = await resultQuery.next()
-    if (found.length < 1) {
-      await new Promise(r => setTimeout(r, i * 1000))
-      continue
-    }
-    break
-  }
+  const request = new Tozny.types.Search()
+  request.match({ records: testRecords[0].meta.recordId })
+  const resultQuery = await writer.search(request)
+  await ops.waitForNext(resultQuery, f => f.length === 10)
 })
 
 afterAll(async () => {

--- a/__tests__/secret.test.js
+++ b/__tests__/secret.test.js
@@ -37,9 +37,10 @@ beforeAll(async () => {
 
 describe('Tozny identity client', () => {
   it('can create a secret', async () => {
+    const testName = `test-secret-${uuidv4()}`
     const secret = {
       secretType: 'Credential',
-      secretName: `test-secret-${uuidv4()}`,
+      secretName: testName,
       secretValue: 'secret-value',
       description: 'this is a description',
     }
@@ -97,51 +98,58 @@ describe('Tozny identity client', () => {
     expect(ops.createSecret(secretValueEmpty)).rejects.toThrow()
   })
   it('can create a secret, and list it', async () => {
+    const testName = `test-secret-${uuidv4()}`
     const secret = {
       secretType: 'Credential',
-      secretName: `test-secret-${uuidv4()}`,
+      secretName: testName,
       secretValue: 'secret-value',
       description: 'this is a description',
     }
+    // use local search to wait
     await ops.createSecret(realmConfig, identity, secret)
-    let query = await ops.getSecrets(realmConfig, identity, 10)
-    let result = await ops.waitForNext(query)
+    // wait for proper indexing of secret
+    let query = await identity.getSecrets(10)
+    await waitForNextOfName(query, testName)
+    // run list in test environment
+    let result = await ops.getSecrets(realmConfig, identity, 10)
     expect(result[0].data.secretValue).toBe('secret-value')
     expect(result[0].meta.plain.secretType).toBe('Credential')
   })
   it('can create a secret and update', async () => {
+    const testName = `test-secret-${uuidv4()}`
     const oldSecret = {
       secretType: 'Credential',
-      secretName: `test-secret-updatetest35558800`,
+      secretName: testName,
       secretValue: 'secret-value',
       description: 'this is a description',
     }
     const newSecret = {
       secretType: 'Credential',
-      secretName: `test-secret-updatetest35558800`,
+      secretName: testName,
       secretValue: 'updatedSecretValue',
       description: 'this is a description',
     }
     await ops.createSecret(realmConfig, identity, oldSecret)
     await ops.updateSecret(realmConfig, identity, oldSecret, newSecret)
-    let query = await ops.getSecrets(realmConfig, identity, 100)
-    let secretsWithUpdatedRecord = await ops.waitForNext(query)
-    let newLengthSecrets = secretsWithUpdatedRecord.length
+    const query = await identity.getSecrets(100)
+    const secretsWithUpdatedRecord = await waitForNextOfName(query, testName, 2)
+    const newLengthSecrets = secretsWithUpdatedRecord.length
     // Tests
     expect(
       secretsWithUpdatedRecord[newLengthSecrets - 1].data.secretValue
     ).toBe('updatedSecretValue') // the new Secret is also created
   })
   it('cannot update secret of different type', async () => {
+    const testName = `test-secret-${uuidv4()}`
     const oldSecret = {
       secretType: 'Credential',
-      secretName: `test-secret-updatetest35558800`,
+      secretName: testName,
       secretValue: 'secret-value',
       description: 'this is a description',
     }
     const newSecret = {
       secretType: 'Note',
-      secretName: `test-secret-updatetest35558800`,
+      secretName: testName,
       secretValue: 'updatedSecretValue',
       description: 'this is a description',
     }
@@ -151,15 +159,17 @@ describe('Tozny identity client', () => {
     ).rejects.toThrow()
   })
   it('cannot update secret of different name', async () => {
+    const testName = `test-secret-${uuidv4()}`
+    const notTestName = `test-secret-${uuidv4()}`
     const oldSecret = {
       secretType: 'Credential',
-      secretName: `test-secret-updatetest35558800`,
+      secretName: testName,
       secretValue: 'secret-value',
       description: 'this is a description',
     }
     const newSecret = {
       secretType: 'Credential',
-      secretName: `test-secret`,
+      secretName: notTestName,
       secretValue: 'updatedSecretValue',
       description: 'this is a description',
     }
@@ -169,3 +179,32 @@ describe('Tozny identity client', () => {
     ).rejects.toThrow()
   })
 })
+
+/**
+ * Returns a search result filtered to contain only the secrets with the given name
+ *
+ * If numRequired is set, then it will ensure the results contains at least that many
+ * secret are found. By default it ensures at least one secret of the given name
+ * exists before returning.
+ *
+ * If the result gets to the end of the 10 second timeout period, this method throws.
+ *
+ * @param {SearchResult} query A secrets search result
+ * @param {string} name The name of the secrets being looked for
+ * @param {int} numRequired The number of secrets which should be found before returning
+ */
+async function waitForNextOfName(query, name, numRequired = 1) {
+  const floor = numRequired - 1
+  let filtered
+  const results = await ops.waitForNext(query, found => {
+    filtered = found.filter(i => i.meta.plain.secretName === name)
+    return filtered.length > floor
+  })
+  if (filtered.length < numRequired) {
+    const stringifiedResults = JSON.stringify(results, null, '  ')
+    throw new Error(
+      `Did not find ${numRequired} secret{s} with name ${name} in results: ${stringifiedResults}`
+    )
+  }
+  return filtered
+}

--- a/__tests__/utils/operations.js
+++ b/__tests__/utils/operations.js
@@ -658,13 +658,23 @@ module.exports = {
           realmConfig.apiUrl
         )
         const user = realm.fromObject(userJSON)
-        return user['getSecrets'](limit)
+        return user
+          .getSecrets(limit)
+          .then(function(r) {
+            return r.next()
+          })
+          .then(function(list) {
+            return list.map(function(record) {
+              return record.serializable()
+            })
+          })
+          .then(JSON.stringify)
       },
       JSON.stringify(config),
       user.stringify(),
       limit
     )
-    return secretList
+    return Promise.all(JSON.parse(secretList).map(Tozny.types.Record.decode))
   },
   async updateSecret(config, user, oldSecret, newSecret) {
     const secretResponse = await runInEnvironment(
@@ -686,21 +696,28 @@ module.exports = {
     )
     return secretResponse
   },
-  async waitForNext(query) {
+  async waitForNext(query, test = f => f.length > 0) {
+    // short circuit for already done queries
+    if (query.done) {
+      return []
+    }
+    const originalAfterIndex = query.afterIndex
     // Start with a very short delay as immediate fetch of results right after writing
-    // sometimes failes, but even with a very short window of wait it can succeed
+    // sometimes fails, but even with a very short window of wait it can succeed
     // first try.
     await new Promise(r => setTimeout(r, 200))
-    // 10-second timeout period, 50 rounds of 200 miliseconds rounds.
+    // 30-second timeout period
+    const start = new Date()
     let found
-    for (let i = 0; i < 50; i++) {
+    while (new Date() - start < 30000) {
       query.done = false
+      query.afterIndex = originalAfterIndex
       found = await query.next()
-      if (found.length > 0) {
+      if (test(found)) {
         break
       }
-      // delay half a second between tries
-      await new Promise(r => setTimeout(r, i * 200))
+      // delay 200 milliseconds between tries
+      await new Promise(r => setTimeout(r, 200))
     }
     return found
   },


### PR DESCRIPTION
I believe this set of changes will stabilize our test runs from Travis. It seems like a lot, but the changes are all pretty small tweaks, really minor. Biggest thing is there was some instability in going to and from the test environment and waiting for search results to get indexed. (Also found some bugs in our test configuration code)

Updates:

- Make sure local test options are respected as boolean values
- Update wait for next helper
  - switch to a while loop for more precise timeout (turned out it wasn't needed, but I kept it more precise)
  - short circuit the request if it is already recorded as done
  - make sure to reset pagination on each loop
  - take a test function which defaults to the previous length check to allow use-case specific testing of expected search results
- Define secrets specific helper which waits for secrets with a specific name to index, and filters search results to only contain secrets with that name
- Update names to use a local variable in each secret test
- Adjust the ops getSecrets() to run the methods in the test environment only, including running next
- Switch tests not directly testing getSecrets to use the direct identity client `getSecrets()` method
- Consume new wait for next helper in search tests