### PR TITLE
use emails we control for test resources

### DIFF
--- a/__tests__/identity.test.js
+++ b/__tests__/identity.test.js
@@ -7,6 +7,7 @@ const {
   testTozIDGroupName,
 } = global
 const Tozny = require('../node')
+const { testEmail } = require('./utils')
 const ops = require('./utils/operations')
 
 jest.setTimeout(10000000)
@@ -35,7 +36,7 @@ beforeAll(async () => {
     username,
     password,
     clientRegistrationToken,
-    `${username}@example.com`
+    testEmail(username)
   )
   identity = await realm.login(username, password)
 })
@@ -54,7 +55,7 @@ describe('Tozny identity client', () => {
   })
   it('can do identity look ups based on emails', async () => {
     let emails = []
-    emails.push(`${username}@example.com`) // Current User
+    emails.push(testEmail(username)) // Current User
     const response = await ops.searchRealmIdentitiesByEmail(
       realmConfig,
       identity,
@@ -62,7 +63,7 @@ describe('Tozny identity client', () => {
     )
     const expectedData = {
       realm_username: username,
-      realm_email: `${username}@example.com`,
+      realm_email: testEmail(username),
     }
     expect(response.search_criteria).toBe('Email')
     expect(response.searched_identities_information[0]).toMatchObject(
@@ -79,7 +80,7 @@ describe('Tozny identity client', () => {
     )
     const expectedData = {
       realm_username: username,
-      realm_email: `${username}@example.com`,
+      realm_email: testEmail(username),
     }
     expect(response.search_criteria).toBe('Username')
     expect(response.searched_identities_information[0]).toMatchObject(
@@ -101,11 +102,11 @@ describe('Tozny identity client', () => {
     const response = await ops.searchIdentityByEmail(
       realmConfig,
       identity,
-      `${username}@example.com`
+      testEmail(username)
     )
     const expectedData = {
       realm_username: username,
-      realm_email: `${username}@example.com`,
+      realm_email: testEmail(username),
     }
     expect(response).toMatchObject(expectedData)
   })
@@ -117,7 +118,7 @@ describe('Tozny identity client', () => {
     )
     const expectedData = {
       realm_username: username,
-      realm_email: `${username}@example.com`,
+      realm_email: testEmail(username),
     }
     expect(response).toMatchObject(expectedData)
   })

--- a/__tests__/secret.test.js
+++ b/__tests__/secret.test.js
@@ -3,6 +3,7 @@ const { apiUrl, idRealmName, idAppName, clientRegistrationToken } = global
 const Tozny = require('../node')
 const ops = require('./utils/operations')
 const { SECRET_UUID } = require('../lib/utils/constants')
+const { testEmail } = require('./utils')
 
 jest.setTimeout(100000)
 
@@ -35,14 +36,14 @@ beforeAll(async () => {
     username,
     password,
     clientRegistrationToken,
-    `${username}@example.com`
+    testEmail(username)
   )
   identity = await realm.login(username, password)
   await realm.register(
     username2,
     password2,
     clientRegistrationToken,
-    `${username2}@example.com`
+    testEmail(username2)
   )
   identity2 = await realm.login(username2, password2)
   /* this is commented out until tests can be written that work with

--- a/__tests__/utils/index.js
+++ b/__tests__/utils/index.js
@@ -1,0 +1,12 @@
+/**
+ * Creates an email address to use in the test environment.
+ * @param {string} suffix
+ * @returns {string}
+ */
+function testEmail(suffix) {
+  return `test-emails-group+${suffix}@tozny.com`
+}
+
+module.exports = {
+  testEmail,
+}

--- a/__tests__/utils/operations.js
+++ b/__tests__/utils/operations.js
@@ -1,4 +1,5 @@
 const { v4: uuidv4 } = require('uuid')
+const { testEmail } = require('.')
 const { runInEnvironment, apiUrl, clientRegistrationToken } = global
 const Tozny = require('../../node')
 
@@ -453,7 +454,7 @@ module.exports = {
     return JSON.parse(result)
   },
   async registerIdentity(config, realm) {
-    const username = `integration-user-${uuidv4()}@example.com`
+    const username = testEmail(`integration-user-${uuidv4()}`)
     const password = uuidv4()
     const user = await runInEnvironment(
       function (realmJSON, clientRegistrationToken, username, password) {
@@ -469,7 +470,7 @@ module.exports = {
             username,
             password,
             clientRegistrationToken,
-            `${username}@example.com`
+            testEmail(username)
           )
           .then(function (user) {
             return user.stringify()


### PR DESCRIPTION
I was looking into why the ci pipeline fails. I ran out of time for that (created new ticket, verified that the failing tests functionality still works) but i found these emails that we dont own in the test suite. not sure if they actually trigger emails to be sent or not, but seems worth replacing them regardless.