### PR TITLE
[WR-384] register webauthn and search mfa

### DIFF
--- a/__tests__/identity.test.js
+++ b/__tests__/identity.test.js
@@ -339,4 +339,24 @@ describe('Tozny identity client', () => {
     expect(policy.requiredApprovals).not.toBeUndefined()
     expect(policy.maxAccessDurationSeconds).not.toBeUndefined()
   })
+
+  it('can initiate a webauthn mfa challenge for this client', async () => {
+    const response = await ops.initiateWebAuthnChallenge(realmConfig, identity)
+    expect(response).not.toBeUndefined()
+    expect(typeof response.tabId).toBe('string')
+    expect(response.challengeData).toMatchObject({
+      challenge: expect.any(String),
+      username: expect.stringMatching(username),
+      userid: expect.any(String),
+      attestationConveyancePreference: expect.any(String),
+      authenticatorAttachment: expect.any(String),
+      excludeCredentialIds: expect.any(String),
+      requireResidentKey: expect.any(String),
+      signatureAlgorithms: expect.any(String),
+      rpId: expect.any(String),
+      rpEntityName: expect.any(String),
+      userVerificationRequirement: expect.any(String),
+      createTimeout: expect.any(Number),
+    })
+  })
 })

--- a/__tests__/utils/operations.js
+++ b/__tests__/utils/operations.js
@@ -1370,4 +1370,22 @@ module.exports = {
     )
     return JSON.parse(result)
   },
+  async initiateWebAuthnChallenge(config, user) {
+    const result = await runInEnvironment(
+      async function (realmJSON, userJSON) {
+        const realmConfig = JSON.parse(realmJSON)
+        const realm = new Tozny.identity.Realm(
+          realmConfig.realmName,
+          realmConfig.appName,
+          realmConfig.brokerTargetUrl,
+          realmConfig.apiUrl
+        )
+        const user = realm.fromObject(userJSON)
+        return user.initiateWebAuthnChallenge().then(JSON.stringify)
+      },
+      JSON.stringify(config),
+      user.stringify()
+    )
+    return JSON.parse(result)
+  },
 }

--- a/lib/identity/client.js
+++ b/lib/identity/client.js
@@ -22,6 +22,7 @@ const {
   InitiateWebAuthnChallengeData,
   Search,
   errors,
+  IdentityMFADevices,
 } = require('../../types')
 
 async function fetchToken(client, appName) {
@@ -1372,6 +1373,82 @@ class Client extends PartialClient {
     await checkStatus(response)
     const data = await response.json()
     return InitiateWebAuthnChallengeData.decode(data)
+  }
+
+  /**
+   * `registerWebAuthnDevice` finalizes the registration of a WebAuthn MFA device for this identity.
+   * @param {PublicKeyCredential} publicKeyCredential this is the response from a call to `navigator.credentials.create`
+   * @param {string} deviceName a name for this device.
+   * @param {string} tabId the id from the initiation challenge call. used to track session across api calls.
+   * @returns {IdentityMFADevices}
+   */
+  // Note: Supporting cross identity registration? Add an optional identity id arg w/ fallback to this client.
+  async registerWebAuthnDevice(publicKeyCredential, deviceName, tabId) {
+    const sessionToken = await this.agentToken()
+    const toznyId = this.storage.config.clientId
+    const response = await this.storage.authenticator.tsv1Fetch(
+      `${this.storage.config.apiUrl}/v1/identity/mfa`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Tozny-Session': sessionToken,
+        },
+        body: JSON.stringify({
+          identity_id: toznyId,
+          tab_id: tabId,
+          mfa_devices: {
+            webauthn:
+              InitiateWebAuthnChallengeData.convertPublicKeyCredentialToRegistrationData(
+                publicKeyCredential,
+                deviceName
+              ),
+          },
+        }),
+      }
+    )
+    await checkStatus(response)
+    const data = await response.json()
+    return IdentityMFADevices.decode(data)
+  }
+
+  /**
+   * `searchIdentityMFADeviceCredentials` finds details of MFA devices for the identities matching the `searchParams`.
+   * If no `searchParams` are provided, it will query for the current identity's MFA devices.
+   * Only realm admins have permission to query the details of other identities' MFA devices.
+   * @param {string} realmName Name of realm
+   * @param {object} [searchParams] Data containing info on which users to find MFA devices for. defaults to this client's identity.
+   *                                All search parameters are taken as to be an OR query.
+   * @param {string[]} [searchParams.toznyIds] List of Tozny client ids to search over
+   * @param {string[]} [searchParams.userIds] List of user ids to search over
+   * @returns {IdentityMFADevices}
+   */
+  async searchIdentityMFADeviceCredentials(realmName, searchParams) {
+    const toznyIds = (searchParams && searchParams.toznyIds) || []
+    const userIds = (searchParams && searchParams.userIds) || []
+    const searchIsEmpty =
+      !searchParams || (toznyIds.length === 0 && userIds.length === 0)
+    if (searchIsEmpty) {
+      // fallback to this client's identity if search is empty.
+      toznyIds.push(this.storage.config.clientId)
+    }
+    const response = await this.storage.authenticator.tsv1Fetch(
+      `${this.storage.config.apiUrl}/v1/identity/mfa/search`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          realm_name: realmName,
+          tozny_ids: toznyIds,
+          user_ids: userIds,
+        }),
+      }
+    )
+    await checkStatus(response)
+    const data = await response.json()
+    return data.identities_credentials.map(IdentityMFADevices.decode)
   }
 }
 

--- a/lib/identity/client.js
+++ b/lib/identity/client.js
@@ -16,11 +16,12 @@ const {
   PRIVATE_KEY_LENGTH,
 } = require('../../lib/utils/constants')
 const {
-  GroupMember,
-  Search,
-  errors,
   AccessRequest,
   AccessRequestSearchResponse,
+  GroupMember,
+  InitiateWebAuthnChallengeData,
+  Search,
+  errors,
 } = require('../../types')
 
 async function fetchToken(client, appName) {
@@ -148,7 +149,7 @@ class Client extends PartialClient {
   /**
    * Get the current session JWT for this identity.
    *
-   * @returns {string} The JWT string of the current session token
+   * @returns {Promise<string>} The JWT string of the current session token
    */
   async agentToken() {
     const info = await this.agentInfo()
@@ -1347,6 +1348,30 @@ class Client extends PartialClient {
         })
       ),
     }))
+  }
+
+  /**
+   * Initiates the challenge for registering a WebAuthn MFA device for this identity.
+   * @returns {Promise<InitiateWebAuthnChallengeData>}
+   */
+  // Note: extending for use w/ different identity id? make the prop optional with a fallback to this client.
+  async initiateWebAuthnChallenge() {
+    const sessionToken = await this.agentToken()
+    const toznyId = this.storage.config.clientId
+    const response = await this.storage.authenticator.tsv1Fetch(
+      `${this.storage.config.apiUrl}/v1/identity/mfa/webauthn-challenge`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Tozny-Session': sessionToken,
+        },
+        body: JSON.stringify({ identity_id: toznyId }),
+      }
+    )
+    await checkStatus(response)
+    const data = await response.json()
+    return InitiateWebAuthnChallengeData.decode(data)
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "cross-fetch": "^3.0.6",
         "libsodium-wrappers": "^0.7.9",
+        "rfc4648": "^1.5.1",
         "spark-md5": "^3.0.1",
         "uuid": "^8.3.2"
       },
@@ -6157,6 +6158,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfc4648": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.1.tgz",
+      "integrity": "sha512-60e/YWs2/D3MV1ErdjhJHcmlgnyLUiG4X/14dgsfm9/zmCWLN16xI6YqJYSCd/OANM7bUNzJqPY5B8/02S9Ibw=="
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "dev": true,
@@ -12038,6 +12044,11 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
+    },
+    "rfc4648": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.1.tgz",
+      "integrity": "sha512-60e/YWs2/D3MV1ErdjhJHcmlgnyLUiG4X/14dgsfm9/zmCWLN16xI6YqJYSCd/OANM7bUNzJqPY5B8/02S9Ibw=="
     },
     "rimraf": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "cross-fetch": "^3.0.6",
     "libsodium-wrappers": "^0.7.9",
+    "rfc4648": "^1.5.1",
     "spark-md5": "^3.0.1",
     "uuid": "^8.3.2"
   },

--- a/types/identityMFADevices.js
+++ b/types/identityMFADevices.js
@@ -1,0 +1,88 @@
+const Serializable = require('./serializable')
+
+/**
+ * @typedef MFADevice
+ * @type {object}
+ * @property {string} id id of the MFA device
+ * @property {string} type they type of MFA device ("totp" or "webauthn")
+ * @property {string} userLabel the user-friendly name given to the device
+ * @property {string} createdAt a string representation of the creation time of the MFA device.
+ */
+
+/**
+ * @typedef MFADevices
+ * @type {object}
+ * @property {MFADevice[]} totp The timed one-time password device(s) registered to the identity.
+ * @property {MFADevice[]} webauthn The WebAuthn/FIDO2 devices registered to the identity.
+ */
+
+class IdentityMFADevices extends Serializable {
+  /**
+   * @param {string} toznyId The identity's Tozny storage client ID
+   * @param {string} userId The identity's user ID
+   * @param {MFADevices} mfaDevices An object containing the different types of MFA devices the of the user.
+   */
+  constructor(toznyId, userId, mfaDevices) {
+    super()
+    /** @type {string} The identity's Tozny storage client ID */
+    this.toznyId = toznyId
+    /** @type {string} The identity's user ID */
+    this.userId = userId
+    /** @type {MFADevices} An object containing the different types of MFA devices the of the user. */
+    this.mfaDevices = mfaDevices
+  }
+
+  serializable() {
+    return {
+      tozny_id: this.toznyId,
+      user_id: this.userId,
+      totp_device: this.mfaDevices.totp.map(
+        IdentityMFADevices._serializeMFADevice
+      ),
+      webauthn_devices: this.mfaDevices.webauthn.map(
+        IdentityMFADevices._serializeMFADevice
+      ),
+    }
+  }
+
+  /** @returns {IdentityMFADevices} */
+  static decode(json) {
+    const mfaDevices = {
+      totp: (json.totp_device || []).map(IdentityMFADevices._decodeMFADevice),
+      webauthn: (json.webauthn_devices || []).map(
+        IdentityMFADevices._decodeMFADevice
+      ),
+    }
+    return new IdentityMFADevices(json.tozny_id, json.user_id, mfaDevices)
+  }
+
+  /**
+   * serializes our sdk's `MFADevice` object to the API representation
+   * @param {MFADevice} data
+   * @private
+   */
+  static _serializeMFADevice(data) {
+    return {
+      id: data.id,
+      type: data.type,
+      user_label: data.userLabel,
+      created_at: data.createdAt,
+    }
+  }
+
+  /**
+   * converts API MFADevice object to our sdk's `MFADevice` structure
+   * @returns {MFADevice}
+   * @private
+   */
+  static _decodeMFADevice(json) {
+    return {
+      id: json.id,
+      type: json.type,
+      userLabel: json.user_label,
+      createdAt: json.created_at,
+    }
+  }
+}
+
+module.exports = IdentityMFADevices

--- a/types/index.js
+++ b/types/index.js
@@ -1,9 +1,17 @@
+const AccessRequest = require('./accessRequest')
+const AccessRequestSearchResponse = require('./accessRequestSearchResponse')
 const AuthorizerPolicy = require('./authorizerPolicy')
+const Capabilities = require('./capabilities')
 const ClientDetails = require('./clientDetails')
 const ClientInfo = require('./clientInfo')
 const EAKInfo = require('./eakInfo')
 const FileMeta = require('./fileMeta')
+const Group = require('./group')
+const GroupMember = require('./groupMember')
+const GroupMembership = require('./groupMembership')
+const GroupMembershipKeys = require('./groupMembershipKeys')
 const IncomingSharingPolicy = require('./incomingSharingPolicy')
+const InitiateWebAuthnChallengeData = require('./initiateWebAuthnChallengeData')
 const KeyPair = require('./keyPair')
 const Meta = require('./meta')
 const Note = require('./note')
@@ -30,21 +38,22 @@ const SigningKey = require('./signingKey')
 const TozIdEACP = require('./tozIdEACP')
 const ToznyOTPEACP = require('./toznyOTPEACP')
 const errors = require('./errors')
-const Group = require('./group')
-const GroupMembershipKeys = require('./groupMembershipKeys')
-const GroupMembership = require('./groupMembership')
-const Capabilities = require('./capabilities')
-const GroupMember = require('./groupMember')
-const AccessRequest = require('./accessRequest')
-const AccessRequestSearchResponse = require('./accessRequestSearchResponse')
 
 module.exports = {
+  AccessRequest,
+  AccessRequestSearchResponse,
   AuthorizerPolicy,
+  Capabilities,
   ClientDetails,
   ClientInfo,
   EAKInfo,
   FileMeta,
+  Group,
+  GroupMember,
+  GroupMembership,
+  GroupMembershipKeys,
   IncomingSharingPolicy,
+  InitiateWebAuthnChallengeData,
   KeyPair,
   Meta,
   Note,
@@ -71,11 +80,4 @@ module.exports = {
   TozIdEACP,
   ToznyOTPEACP,
   errors,
-  Group,
-  GroupMembershipKeys,
-  GroupMembership,
-  Capabilities,
-  GroupMember,
-  AccessRequest,
-  AccessRequestSearchResponse,
 }

--- a/types/index.js
+++ b/types/index.js
@@ -10,6 +10,7 @@ const Group = require('./group')
 const GroupMember = require('./groupMember')
 const GroupMembership = require('./groupMembership')
 const GroupMembershipKeys = require('./groupMembershipKeys')
+const IdentityMFADevices = require('./identityMFADevices')
 const IncomingSharingPolicy = require('./incomingSharingPolicy')
 const InitiateWebAuthnChallengeData = require('./initiateWebAuthnChallengeData')
 const KeyPair = require('./keyPair')
@@ -52,6 +53,7 @@ module.exports = {
   GroupMember,
   GroupMembership,
   GroupMembershipKeys,
+  IdentityMFADevices,
   IncomingSharingPolicy,
   InitiateWebAuthnChallengeData,
   KeyPair,

--- a/types/initiateWebAuthnChallengeData.js
+++ b/types/initiateWebAuthnChallengeData.js
@@ -1,0 +1,223 @@
+const { base64url } = require('rfc4648')
+const Serializable = require('./serializable')
+
+class InitiateWebAuthnChallengeData extends Serializable {
+  /**
+   * @param {string} tabId a tab id string from the server that corresponds to the session that initiated the challenge
+   * @param {object} challengeData the challenge data
+   * @param {string} challengeData.challenge
+   * @param {string} challengeData.rpId
+   * @param {string} challengeData.rpEntityName
+   * @param {string} challengeData.signatureAlgorithms
+   * @param {string} challengeData.userid
+   * @param {string} challengeData.username
+   * @param {string} challengeData.attestationConveyancePreference
+   * @param {string} challengeData.authenticatorAttachment
+   * @param {string} challengeData.requireResidentKey
+   * @param {string} challengeData.userVerificationRequirement
+   * @param {number} challengeData.createTimeout
+   * @param {string} challengeData.excludeCredentialIds
+   */
+  constructor(tabId, challengeData) {
+    super()
+    this.tabId = tabId
+    this.challengeData = challengeData
+  }
+
+  serializable() {
+    let login_context = {
+      challenge: this.login_context.challenge,
+      username: this.login_context.username,
+      user_id: this.login_context.userid,
+      attestation_conveyance_preference:
+        this.login_context.attestationConveyancePreference,
+      authenticator_attachment: this.login_context.authenticatorAttachment,
+      exclude_credential_ids: this.login_context.excludeCredentialIds,
+      require_resident_key: this.login_context.requireResidentKey,
+      signature_algorithms: this.login_context.signatureAlgorithms,
+      relying_party_id: this.login_context.rpId,
+      relying_party_name: this.login_context.rpEntityName,
+      user_verification_requirement:
+        this.login_context.userVerificationRequirement,
+      create_timeout: this.login_context.createTimeout,
+    }
+
+    return { tab_id: this.tab_id, login_context }
+  }
+
+  /**
+   * example json:
+   * {
+   *   "tab_id": "suXnLMlUbNc",
+   *   "login_context": {
+   *     "challenge": "P0yk9VBLR6u7ZzpMM6nczg",
+   *     "username": "test-emails-group+webauth-init-test@tozny.com",
+   *     "user_id": "OTgxNDY0NWMtZDIwMS00MmRiLWFkYzItZjU4Y2EzZTU0MGEy",
+   *     "attestation_conveyance_preference": "not specified",
+   *     "authenticator_attachment": "not specified",
+   *     "exclude_credential_ids": "",
+   *     "require_resident_key": "not specified",
+   *     "signature_algorithms": "-7",
+   *     "relying_party_id": "id.tozny.com",
+   *     "relying_party_name": "tozny",
+   *     "user_verification_requirement": "not specified",
+   *     "create_timeout": 0
+   *   }
+   * }
+   */
+  static decode(json) {
+    const challengeData = {
+      challenge: json.login_context.challenge,
+      username: json.login_context.username,
+      userid: json.login_context.user_id,
+      attestationConveyancePreference:
+        json.login_context.attestation_conveyance_preference,
+      authenticatorAttachment: json.login_context.authenticator_attachment,
+      excludeCredentialIds: json.login_context.exclude_credential_ids,
+      requireResidentKey: json.login_context.require_resident_key,
+      signatureAlgorithms: json.login_context.signature_algorithms,
+      rpId: json.login_context.relying_party_id,
+      rpEntityName: json.login_context.relying_party_name,
+      userVerificationRequirement:
+        json.login_context.user_verification_requirement,
+      createTimeout: json.login_context.create_timeout,
+    }
+
+    return new InitiateWebAuthnChallengeData(json.tab_id, challengeData)
+  }
+
+  /**
+   * converts the challenge data into the object passed to `navigator.credentials.create` API
+   * inspired by https://github.com/keycloak/keycloak/blob/e23969/themes/src/main/resources/theme/base/login/webauthn-register.ftl#L24
+   */
+  toPublicKeyCredentialCreationOptions() {
+    const {
+      challenge,
+      rpEntityName,
+      rpId,
+      signatureAlgorithms,
+      userid,
+      username,
+      // optional parameters
+      attestationConveyancePreference,
+      authenticatorAttachment,
+      requireResidentKey,
+      userVerificationRequirement,
+      createTimeout,
+      excludeCredentialIds,
+    } = this.challengeData
+
+    const publicKey = {
+      challenge: base64url.parse(challenge, { loose: true }),
+      rp: { id: rpId, name: rpEntityName },
+      user: {
+        id: base64url.parse(userid, { loose: true }),
+        name: username,
+        displayName: username,
+      },
+      pubKeyCredParams: getPubKeyCredParams(signatureAlgorithms),
+    }
+
+    // handle optional parameters for future-proofing webauthn policy changes
+    if (attestationConveyancePreference !== 'not specified')
+      publicKey.attestation = attestationConveyancePreference
+
+    let authenticatorSelection = {}
+    let isAuthenticatorSelectionSpecified = false
+
+    if (authenticatorAttachment !== 'not specified') {
+      authenticatorSelection.authenticatorAttachment = authenticatorAttachment
+      isAuthenticatorSelectionSpecified = true
+    }
+
+    if (requireResidentKey !== 'not specified') {
+      if (requireResidentKey === 'Yes')
+        authenticatorSelection.requireResidentKey = true
+      else authenticatorSelection.requireResidentKey = false
+      isAuthenticatorSelectionSpecified = true
+    }
+
+    if (userVerificationRequirement !== 'not specified') {
+      authenticatorSelection.userVerification = userVerificationRequirement
+      isAuthenticatorSelectionSpecified = true
+    }
+
+    if (isAuthenticatorSelectionSpecified)
+      publicKey.authenticatorSelection = authenticatorSelection
+
+    if (createTimeout != 0) publicKey.timeout = createTimeout * 1000
+
+    const excludeCredentials = getExcludeCredentials(excludeCredentialIds)
+    if (excludeCredentials.length > 0)
+      publicKey.excludeCredentials = excludeCredentials
+
+    return publicKey
+  }
+
+  /**
+   * This helper function is used to convert the registration data from a hardware security key into
+   * the structure & encoding used by Tozny's WebAuthn registration API.
+   * @param {PublicKeyCredential} publicKeyCredential this is the response from a call to `navigator.credentials.create`
+   * @param {string} deviceName a name for this device.
+   */
+  static convertPublicKeyCredentialToRegistrationData(
+    publicKeyCredential,
+    deviceName
+  ) {
+    return {
+      client_data_json: b64urlEncode(
+        publicKeyCredential.response.clientDataJSON
+      ),
+      attestation_object: b64urlEncode(
+        publicKeyCredential.response.attestationObject
+      ),
+      public_key_credential_id: b64urlEncode(publicKeyCredential.rawId),
+      authenticator_label: deviceName,
+    }
+  }
+}
+
+// https://github.com/keycloak/keycloak/blob/e23969/themes/src/main/resources/theme/base/login/webauthn-register.ftl#L113
+function getPubKeyCredParams(signatureAlgorithms) {
+  const pubKeyCredParams = []
+  if (signatureAlgorithms === '') {
+    pubKeyCredParams.push({ type: 'public-key', alg: -7 })
+    return pubKeyCredParams
+  }
+  const signatureAlgorithmsList = signatureAlgorithms.split(',')
+
+  for (let i = 0; i < signatureAlgorithmsList.length; i++) {
+    pubKeyCredParams.push({
+      type: 'public-key',
+      alg: signatureAlgorithmsList[i],
+    })
+  }
+  return pubKeyCredParams
+}
+
+// https://github.com/keycloak/keycloak/blob/e23969/themes/src/main/resources/theme/base/login/webauthn-register.ftl#L130
+function getExcludeCredentials(excludeCredentialIds) {
+  let excludeCredentials = []
+  if (excludeCredentialIds === '') return excludeCredentials
+
+  let excludeCredentialIdsList = excludeCredentialIds.split(',')
+
+  for (let i = 0; i < excludeCredentialIdsList.length; i++) {
+    excludeCredentials.push({
+      type: 'public-key',
+      id: Buffer.from(excludeCredentialIdsList[i], 'base64'),
+    })
+  }
+  return excludeCredentials
+}
+
+/**
+ * converts a string to a base64url encoded string of the byte array
+ * a helper func for webauthn registration data construction.
+ */
+function b64urlEncode(str) {
+  const bytes = new Uint8Array(str)
+  return base64url.stringify(bytes)
+}
+
+module.exports = InitiateWebAuthnChallengeData

--- a/types/initiateWebAuthnChallengeData.js
+++ b/types/initiateWebAuthnChallengeData.js
@@ -89,6 +89,7 @@ class InitiateWebAuthnChallengeData extends Serializable {
   /**
    * converts the challenge data into the object passed to `navigator.credentials.create` API
    * inspired by https://github.com/keycloak/keycloak/blob/e23969/themes/src/main/resources/theme/base/login/webauthn-register.ftl#L24
+   * @returns {PublicKeyCredentialCreationOptions} the public key credential creation options to pass to navigator api
    */
   toPublicKeyCredentialCreationOptions() {
     const {


### PR DESCRIPTION
Adds support for WebAuthn registration and MFA device searching.

To unblock @Mrhea, I've only included automated tests of the webauthn challenge initiation. However, i have manually tested the functionality of all three methods and have high confidence in them. i will be adding automated tests for these in a followup!

see readme docs for details.