### PR TITLE
Add Edit Permission to Shared Group Record

### DIFF
--- a/lib/storage/client.js
+++ b/lib/storage/client.js
@@ -2082,6 +2082,91 @@ class Client extends CryptoConsumer {
         throw new Error('Error while updating subscription.')
     }
   }
+
+
+   /**
+   * Grant another E3DB client access to records of a particular type.
+   *
+   * @param {string} type     Type of records to share
+   * @param {string} readerId Client ID or email address of reader to grant access to
+   * @param {string} recordId Record ID of reader to grant access to
+
+   * @returns {Promise<bool>}
+   */
+   async shareWithUser(type, readerId,recordId) {
+    if (EMAIL.test(readerId)) {
+      let clientInfo = await this.clientInfo(readerId)
+      return this.share(type, clientInfo.clientId)
+    }
+    // Share on behalf of ourself
+    return this.shareOnBehalfOfUser(this.config.clientId, type, readerId,recordId)
+  }
+
+  /**
+   * Grant another E3DB client access to records of a particular type for a writer.
+   *
+   * @param {string} writerId Client ID of the writer to grant for
+   * @param {string} type     Type of records to share
+   * @param {string} readerId Client ID or reader to grant access to
+   * @param {string} recordId Record ID to grant access
+
+   * @returns {Promise<bool>}
+   */
+  async shareOnBehalfOfUser(writerId, type, readerId, recordId) {
+    // Don't need to share if the reader is the writer
+    if (readerId === writerId) {
+      return true
+    }
+   await shared.putAccessKeyForReader(this, writerId, type, readerId)
+    const policy = {
+      allow: [
+        { read: {} }
+      //  (canEdit ? [{ edit: {} }] : []) // Conditionally add Edit privilege
+      ]
+    };
+        return shared.putPolicyToRecord(this, policy, writerId, writerId, readerId,recordId, type)
+  }
+
+/**
+   * Revoke another E3DB client's access to records of a particular type.
+   *
+   * @param {string} type     Type of records to share
+   * @param {string} readerId Client ID or email address of reader to grant access from
+   *  @param {string} recordId Record ID  to grant access 
+
+   * @returns {Promise<bool>}
+   */
+async revokeRecord(type, readerId,recordId) {
+  if (EMAIL.test(readerId)) {
+    let clientInfo = await this.clientInfo(readerId)
+    return this.revoke(type, clientInfo.clientId)
+  }
+
+  // Revoke on behalf of self
+  return this.revokeOnBehalfOfRecord(this.config.clientId, type, readerId,recordId)
+}
+
+/**
+ * Revoke another E3DB client's access to records of a particular writer and type.
+ *
+ * @param {string} writerId Client ID of the writer to revoke access to
+ * @param {string} type     Type of records to revoke share for
+ * @param {string} readerId Client ID of reader to revoke access from
+ *
+ * @returns {Promise<bool>}
+ */
+async revokeOnBehalfOfRecord(writerId, type, readerId,recordId) {
+  if (readerId === writerId) {
+    return true
+  }
+  // Delete any existing access keys
+  await shared.deleteAccessKey(this, writerId, writerId, readerId, type)
+  let policy = { deny: [{ read: {} }] }
+  return shared.putPolicyToRecord(this, policy, writerId, writerId, readerId, recordId,type)
+}
+
+
+  
 }
 
 module.exports = Client

--- a/lib/storage/client.js
+++ b/lib/storage/client.js
@@ -294,6 +294,47 @@ class Client extends CryptoConsumer {
       .then((record) => shared.decryptRecord(this, record))
   }
 
+   /**
+   * Update the Record which is shared under the group.
+   * @param {Record} record The fully-constructed record object, as returned by `encrypt()`
+   * @param {groupID} groupId of shared record 
+   * @return {Promise<Record>}
+   */
+  async updateGroupSharedRecord(record, groupID){
+    let recordId = record.meta.recordId
+    let version = record.meta.version
+
+    // Update record signature
+    let recordInfo = new RecordInfo(record.meta, record.data)
+    // eslint-disable-next-line require-atomic-updates
+    record.signature =
+      this.config.version > 1 ? await this.sign(recordInfo) : null
+    let encrypted = await shared.encryptRecord(this, record)
+    return this.authenticator
+      .tokenFetch(
+        this.config.apiUrl +
+        '/v1/storage/groups/' +
+        groupID+ '/records/safe/' +
+        recordId +
+        '/' +
+        version,
+        {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: encrypted.stringify(),
+        }
+      )
+      .then(checkStatus)
+      .then((response) => response.json())
+      .then(Record.decode)
+      .then((rec) => {
+        return rec
+      })
+      .then((record) => shared.decryptRecord(this, record)) 
+
+  }
   /**
    * Deletes a record from the E3DB system
    *

--- a/lib/storage/shared.js
+++ b/lib/storage/shared.js
@@ -209,7 +209,7 @@ async function deleteAccessKey(client, writerId, userId, readerId, type) {
  *
  * @returns {Promise<bool>} Whether the policy was written successfully
  */
-async function putPolicy(client, policy, writerId, userId, readerId, type) {
+async function putPolicy(client, policy, writerId, userId, readerId, recordId,type) {
   let request = await client.authenticator.tokenFetch(
     client.config.apiUrl +
       '/v1/storage/policy/' +
@@ -218,7 +218,7 @@ async function putPolicy(client, policy, writerId, userId, readerId, type) {
       userId +
       '/' +
       readerId +
-      '/' +
+      '/' + recordId +
       type,
     {
       method: 'PUT',
@@ -485,6 +485,43 @@ async function issueNoteChallenge(client, requestParams, body = {}) {
   )
   await checkStatus(request)
   return request.json()
+}
+
+
+/**
+ * Add or update an policy to the TozStore storage service
+ *
+ * @param {Client} client   TozStore Client instance
+ * @param {object} policy   An object containing the policy definition to write
+ * @param {string} writerId Writer/Authorizer controlling data access
+ * @param {string} userId   The client ID of the subject of the protected data
+ * @param {string} readerId The client ID whose access is being updated
+ * @param {string} type     Record type for which the policy will be used
+ *
+ * @returns {Promise<bool>} Whether the policy was written successfully
+ */
+
+async function putPolicyToRecord(client, policy, writerId, userId, readerId, recordId,type) {
+  let request = await client.authenticator.tokenFetch(
+    client.config.apiUrl +
+      '/v1/storage/policy/' +
+      writerId +
+      '/' +
+      userId +
+      '/' +
+      readerId +
+      '/' + recordId + '/' +
+      type,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(policy),
+    }
+  )
+  await checkStatus(request)
+  return true
 }
 
 module.exports = {

--- a/lib/storage/shared.js
+++ b/lib/storage/shared.js
@@ -542,4 +542,5 @@ module.exports = {
   readNote,
   deleteNote,
   issueNoteChallenge,
+  putPolicyToRecord
 }

--- a/lib/storage/shared.js
+++ b/lib/storage/shared.js
@@ -496,6 +496,8 @@ async function issueNoteChallenge(client, requestParams, body = {}) {
  * @param {string} writerId Writer/Authorizer controlling data access
  * @param {string} userId   The client ID of the subject of the protected data
  * @param {string} readerId The client ID whose access is being updated
+ *  @param {string} readerId The client ID whose access is being updated
+
  * @param {string} type     Record type for which the policy will be used
  *
  * @returns {Promise<bool>} Whether the policy was written successfully

--- a/types/capabilities.js
+++ b/types/capabilities.js
@@ -9,6 +9,9 @@ class Capabilities {
     if (capabilityBool.share === true) {
       capabilities.push('SHARE_CONTENT')
     }
+    if (capabilityBool.edit === true) {
+      capabilities.push('EDIT_CONTENT')
+    }
     if (capabilityBool.manage === true) {
       capabilities.push('MANAGE_MEMBERSHIP')
     }
@@ -23,6 +26,9 @@ class Capabilities {
     capabilityArray.forEach((capability) => {
       if (capability === 'SHARE_CONTENT') {
         capabilities['share'] = true
+      }
+      if (capability === 'EDIT_CONTENT') {
+        capabilities['edit'] = true
       }
       if (capability === 'READ_CONTENT') {
         capabilities['read'] = true


### PR DESCRIPTION
1. Adding Edit Capability to the Group's Policy
2. Function "UpdateGroupSharedRecord" allows the users to edit the group shared record when the user has specified policy