### PR TITLE
Auth token undefined check.

### DIFF
--- a/lib/request/authenticatedRequest.js
+++ b/lib/request/authenticatedRequest.js
@@ -131,7 +131,7 @@ class AuthenticatedRequest {
    * @returns {Promise<string>} Promise of a valid authentication header
    */
   async getTokenHeader() {
-    if (this._authToken === null || Date.now() > this._authTokenTimeout) {
+    if (this._authToken === undefined || this._authTokenTimeout === undefined || this._authToken === null || Date.now() > this._authTokenTimeout) {
       if (this.canPerformTokenAuth()) {
         return 'Bearer ' + (await this.tokenAuth())
       }


### PR DESCRIPTION
Js-sdk is not directly imported in internal-compute(lambda), it has been used in js-compute-sdk which is used in broker auth. So, we need to release js-sdk first and then update the version in js-compute-sdk and release then update the js-compute-sdk version in internal-compute.