### PR TITLE
Refresh token expire

### DIFF
--- a/lib/identity/client.js
+++ b/lib/identity/client.js
@@ -102,25 +102,30 @@ async function getNamespace(client, namespace, createIfMissing) {
  * @return {Object} The new _agentToken information with absolute expiry dates
  */
 async function refreshAgentToken(client) {
-  const now = Math.floor(Date.now() / 1000)
-  if (!client._agentToken || client._agentToken.refresh_expiry < now) {
-    throw new errors.identity.SessionExpiredError(
-      'Agent refresh token has expired'
-    )
-  }
-  const bodyData = {
-    refresh_token: client._agentToken.refresh_token,
-  }
-  const request = await client.storage.authenticator.tsv1Fetch(
-    client.config.apiUrl +
-    `/v1/identity/auth/realm/${client.config.realmDomain}/refresh`,
-    {
-      method: 'POST',
-      body: JSON.stringify(bodyData),
+  try {
+    const now = Math.floor(Date.now() / 1000)
+    if (!client._agentToken || client._agentToken.refresh_expiry < now) {
+      throw new errors.identity.SessionExpiredError(
+        'Agent refresh token has expired'
+      )
     }
-  )
-  const agentToken = await credentialedDecodeResponse(request)
-  return convertExpiry(agentToken)
+    const bodyData = {
+      refresh_token: client._agentToken.refresh_token,
+    }
+    const request = await client.storage.authenticator.tsv1Fetch(
+      client.config.apiUrl +
+      `/v1/identity/auth/realm/${client.config.realmDomain}/refresh`,
+      {
+        method: 'POST',
+        body: JSON.stringify(bodyData),
+      }
+    )
+    const agentToken = await credentialedDecodeResponse(request)
+    return convertExpiry(agentToken)
+  } catch (error) {
+    // Preserve the original error stack while adding context
+    throw error instanceof Error ? error : new Error(error)
+  }
 }
 
 /**
@@ -169,13 +174,18 @@ class Client extends PartialClient {
    * @returns {object} the full token info object for the TozID session token.
    */
   async agentInfo() {
-    const now = Math.floor(Date.now() / 1000)
-    if ( !this._agentToken ||  (this._agentToken.expires && this._agentToken.expires < now) || 
-      (this._agentToken.expiry && Date.now() > new Date(this._agentToken.expiry).getTime())
-    ) {
-      this._agentToken = await refreshAgentToken(this)
+    try {
+      const now = Math.floor(Date.now() / 1000)
+      if (!this._agentToken || (this._agentToken.expires && this._agentToken.expires < now) || 
+        (this._agentToken.expiry && Date.now() > new Date(this._agentToken.expiry).getTime())
+      ) {
+        this._agentToken = await refreshAgentToken(this)
+      }
+      return Object.assign({}, this._agentToken)
+    } catch (error) {
+      // Preserve the error and propagate it to the Svelte application
+      throw error instanceof Error ? error : new Error(error)
     }
-    return Object.assign({}, this._agentToken)
   }
 
   async token() {

--- a/lib/identity/client.js
+++ b/lib/identity/client.js
@@ -103,11 +103,12 @@ async function getNamespace(client, namespace, createIfMissing) {
  */
 async function refreshAgentToken(client) {
   try {
-    const now = Math.floor(Date.now() / 1000)
-    if (!client._agentToken || client._agentToken.refresh_expiry < now) {
-      throw new errors.identity.SessionExpiredError(
-        'Agent refresh token has expired'
-      )
+    
+    const now = new Date()
+    const expiry = new Date(client._agentToken.refresh_expiry)
+
+    if (!client._agentToken || expiry < now) {
+      throw new errors.identity.SessionExpiredError('Agent refresh token has expired')
     }
     const bodyData = {
       refresh_token: client._agentToken.refresh_token,


### PR DESCRIPTION
When the refresh token is expired, we need to throw session expired. For that, we are checking refresh token against current date.